### PR TITLE
Exclude login_required modelresults if user is not authenticated

### DIFF
--- a/aldryn_search/views.py
+++ b/aldryn_search/views.py
@@ -44,6 +44,8 @@ class AldrynSearchView(FormMixin, ListView):
         return super(AldrynSearchView, self).get(request, *args, **kwargs)
 
     def get_queryset(self):
+        if not self.request.user.is_authenticated():
+            return self.form.search().exclude(login_required=True)
         return self.form.search()
 
     def get_context_data(self, **kwargs):


### PR DESCRIPTION
Found that `login_required` is stored but not used for filtering.
Since parts of the rendered pages are displayed in search results, private content is exposed to anonymous users.
These two lines seems to do the trick.
