### PR TITLE
Use the queryset to check if there's spelling suggestions

### DIFF
--- a/aldryn_search/views.py
+++ b/aldryn_search/views.py
@@ -76,7 +76,6 @@ class AldrynSearchView(FormMixin, ListView):
         context = super(AldrynSearchView, self).get_context_data(**kwargs)
         context['query'] = self.get_query(self.form)
         context['form'] = self.form
-        results = context['object_list']
-        if results and hasattr(results, 'query') and results.query.backend.include_spelling:
+        if self.object_list.query.backend.include_spelling:
             context['suggestion'] = self.form.get_suggestion()
         return context


### PR DESCRIPTION
When using pagination, `MultipleObjectMixin` evaluates `SearchQuerySet` to a list with the given `page_size` elements.
So `results` never has the `query` property: it's a list.
At this stage `self.object_list` is computed and can be directly used.
