### PR TITLE
Disable indexing the login_required field.

### DIFF
--- a/aldryn_search/base.py
+++ b/aldryn_search/base.py
@@ -101,7 +101,7 @@ class AldrynIndexBase(AbstractIndex):
     language = indexes.CharField()
     description = indexes.CharField(indexed=False, stored=True, null=True)
     pub_date = indexes.DateTimeField(null=True)
-    login_required = indexes.BooleanField(default=False)
+    login_required = indexes.BooleanField(default=False, indexed=False)
     url = indexes.CharField(stored=True, indexed=False)
     title = indexes.CharField(stored=True, indexed=False)
     site_id = indexes.IntegerField(stored=True, indexed=True, null=True)


### PR DESCRIPTION
Indexing boolean fields is [broken on ElasticSearch](https://github.com/toastdriven/django-haystack/issues/866). The current recommendation seems to be setting indexed=False on such fields. Apparently they are still searchable and everything works, according to comments on that issue.