### PR TITLE
Feature/donotindex appconfig without pages

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -96,7 +96,7 @@ Dependencies
 
 When installing from a requirements.txt file please add following lines to it::
 
-    https://github.com/chronossc/django-haystack/archive/2.3.x.zip#egg=django-haystack-2.3.2.dev0
+    https://github.com/chronossc/django-haystack/archive/2.3.x.zip#egg=django-haystack
     https://github.com/aldryn/aldryn-search/archive/feature/donotindex_appconfig_without_pages.zip#egg=aldryn-search
 
 This is required by ``pip>=1.5`` which deprecate dependency links.

--- a/README.rst
+++ b/README.rst
@@ -91,6 +91,16 @@ anytime in it's prepare proccess.
 
 To use this new django-haystack feature, just raise ``haystack.exceptions.DoNotIndex`` in ``prepare`` methods.
 
+Dependencies
+------------
+
+When installing from a requirements.txt file please add following lines to it::
+
+    https://github.com/chronossc/django-haystack/archive/2.3.x.zip#egg=django-haystack-2.3.2.dev0
+    https://github.com/aldryn/aldryn-search/archive/feature/donotindex_appconfig_without_pages.zip#egg=aldryn-search
+
+This is required by ``pip>=1.5`` which deprecate dependency links.
+
 AldrynAppconfigIndexBase
 ------------------------
 

--- a/README.rst
+++ b/README.rst
@@ -83,10 +83,29 @@ Results are paginated according to the ``ALDRYN_SEARCH_PAGINATION`` setting (def
 If set to ``None`` pagination is disabled.
 
 Extra feature
-=============
+=======
 
-django-haystack 2.4.0 will add a new feature that allows us to skip objects from being indexed in any point when preparing data to be indexed.
+This branch adds a feature planed for django-haystack-2.4.0, backported to 2.3.x branch.
+It uses a custom branch of django-haystack that adds support to skip the indexing of an object
+anytime in it's prepare proccess.
 
-This feature was backported to 2.3.x versions and live in https://github.com/chronossc/django-haystack/tree/2.3.x.
+To use this new django-haystack feature, just raise ``haystack.exceptions.DoNotIndex`` in ``prepare`` methods.
 
-Aldryn Search is using this feature in ``feature/donotindex_appconfig_without_pages`` branch to skip objects that has app config namespaces that are not related to any public page.
+AldrynAppconfigIndexBase
+------------------------
+
+Due to how django url resolution works, we can index objects with wrong url. Example:
+
+* For aldryn-newsblog we have following ``NewsBlogConfig`` namespaces: 'foo' and 'bar'.
+* We have a Page with ``application_namespace = 'bar'`` and ``application_urls = 'NewsBlogApp'``.
+* We have the ``<Article 1>`` with ``app_config.namespace = 'foo'``.
+
+When indexing we get ``<Article 1>.get_absolute_url()`` and because it's namespace is ``foo`` and we does not have a newsblog page with ``application_namespace = 'foo'`` it will return url for page with ``application_namespace = 'bar'``.
+
+This will lead to Http 404 error because when newsblog filter the articles it will look for ``bar`` namespace instead ``foo``.
+
+This indexer will skip from indexing objects with namespaces that are not
+related to any published page to avoid index of these entries.
+
+To use that set ``ALDRYN_SEARCH_INDEX_BASE_CLASS`` to ``aldryn_search.base.AldrynAppconfigIndexBase``
+or inherit your ``BaseSearch`` from that class.

--- a/aldryn_search/base.py
+++ b/aldryn_search/base.py
@@ -3,10 +3,18 @@ import warnings
 from django.utils.translation import override
 
 from haystack import indexes
+from haystack.exceptions import DoNotIndex
 
 from .conf import settings
 from .helpers import get_request
 from .utils import clean_join, _get_language_from_alias_func
+
+try:
+    from aldryn_apphooks_config.utils import get_apphook_field_names
+    from cms.models import Page
+    HAS_APPCONFIG = True
+except ImportError:
+    HAS_APPCONFIG = False
 
 
 language_from_alias = _get_language_from_alias_func()
@@ -130,7 +138,30 @@ class AldrynIndexBase(AbstractIndex):
         """
         return None
 
+    def check_for_app_config(self, obj):
+        """
+        This should check for app_config in object and if it exists check
+        if app_config namespace exists in some page. If app_config exists
+        and namespace does not exists in pages we should skip indexing for
+        this object. If app_config does not exists for given object or we
+        can't import appconfig stuff, just ignore.
+        """
+        if HAS_APPCONFIG:
+            apphook_field_names = get_apphook_field_names(obj)
+            results = []
+
+            for field_name in apphook_field_names:
+                app_config = getattr(obj, field_name)
+                if app_config:
+                    pages = Page.objects.public().filter(
+                        application_namespace=app_config.namespace
+                    )
+                    results.append(pages.exists())
+            if not any(results):
+                raise DoNotIndex
+
     def prepare_fields(self, obj, language, request):
+        self.check_for_app_config(obj)
         self.prepared_data['language'] = language
         # We set the following fields here because on some models,
         # the value of these fields is dependent on the active language

--- a/aldryn_search/base.py
+++ b/aldryn_search/base.py
@@ -138,6 +138,30 @@ class AldrynIndexBase(AbstractIndex):
         """
         return None
 
+    def prepare_fields(self, obj, language, request):
+        self.prepared_data['language'] = language
+        # We set the following fields here because on some models,
+        # the value of these fields is dependent on the active language
+        # this being the case we extrapolate the language hacks.
+        self.prepared_data['url'] = self.get_url(obj)
+        self.prepared_data['title'] = self.get_title(obj)
+        self.prepared_data['description'] = self.get_description(obj)
+
+        if self.index_title or getattr(self, 'INDEX_TITLE', False):
+            prepared_text = self.prepared_data['text']
+            prepared_title = self.prepared_data['title']
+            self.prepared_data['text'] = clean_join(
+                ' ', [prepared_title, prepared_text]
+            )
+
+
+class AldrynAppconfigIndexBase(AldrynIndexBase):
+
+    """
+    This class add a check for objects that have app config instances related
+    to it.
+    """
+
     def check_for_app_config(self, obj):
         """
         This should check for app_config in object and if it exists check
@@ -162,17 +186,6 @@ class AldrynIndexBase(AbstractIndex):
 
     def prepare_fields(self, obj, language, request):
         self.check_for_app_config(obj)
-        self.prepared_data['language'] = language
-        # We set the following fields here because on some models,
-        # the value of these fields is dependent on the active language
-        # this being the case we extrapolate the language hacks.
-        self.prepared_data['url'] = self.get_url(obj)
-        self.prepared_data['title'] = self.get_title(obj)
-        self.prepared_data['description'] = self.get_description(obj)
-
-        if self.index_title or getattr(self, 'INDEX_TITLE', False):
-            prepared_text = self.prepared_data['text']
-            prepared_title = self.prepared_data['title']
-            self.prepared_data['text'] = clean_join(
-                ' ', [prepared_title, prepared_text]
-            )
+        return super(AldrynAppconfigIndexBase, self).prepare_fields(
+            obj, language, request
+        )

--- a/aldryn_search/utils.py
+++ b/aldryn_search/utils.py
@@ -4,6 +4,8 @@ from __future__ import unicode_literals
 import six
 
 from lxml.html.clean import Cleaner as LxmlCleaner
+from lxml.etree import ParseError
+
 
 from django.core.exceptions import ImproperlyConfigured
 from django.db import models
@@ -134,19 +136,14 @@ def strip_tags(value):
     strip tags. If value isn't valid, just return value since there is
     no tags to strip.
     """
-    # borrowed from aldryn-search
-
     if isinstance(value, six.string_types):
         value = value.strip()
 
-        if not value:
-            return
-
         try:
             partial_strip = LxmlCleaner().clean_html(value)
-        except ParserError:
-            # error could occur because of invalid html document
-            # we don't want to return empty handed.
+        except ParseError:
+            # Error could occur because of invalid html document,
+            # including '' values. We don't want to return empty handed.
             partial_strip = value
         value = _strip_tags(partial_strip)
         return value.strip()  # clean cases we have <div>\n\n</div>

--- a/setup.py
+++ b/setup.py
@@ -2,36 +2,43 @@ import metadata as m
 
 from setuptools import setup, find_packages
 
-install_requires = [
+INSTALL_REQUIRES = [
     'lxml',
     'setuptools',
-    'Django>=1.4',
+    'Django>=1.4,<1.7',
     'django-appconf',
     'django-cms>=2.4',
     'django-classy-tags>=0.3.2',
-    'django-haystack>=2.0.0',
+    'django-haystack>=2.4.0.dev0',
     'django-spurl',
     'django-standard-form',
     'aldryn-common',
 ]
 
+DEPENDENCY_LINKS = [
+    'https://github.com/chronossc/django-haystack/archive/feature/do_not_index.zip#egg=django-haystack-2.4.0.dev0'  # NOQA
+]
+
 setup(
-    name = m.name,
-    version = m.version,
-    url = m.project_url,
-    license = m.license,
+    name=m.name,
+    version=m.version,
+    url=m.project_url,
+    license=m.license,
     platforms=['OS Independent'],
-    description = m.description,
-    author = m.author,
-    author_email = m.author_email,
+    description=m.description,
+    author=m.author,
+    author_email=m.author_email,
     packages=find_packages(),
-    install_requires = install_requires,
-    include_package_data = True, #Accept all data files and directories matched by MANIFEST.in or found in source control.
-    package_dir = {
-        m.package_name:m.package_name,
+    install_requires=INSTALL_REQUIRES,
+    dependency_links=DEPENDENCY_LINKS,
+    # Accept all data files and directories matched by MANIFEST.in or
+    # found in source control.workon
+    include_package_data=True,
+    package_dir={
+        m.package_name: m.package_name,
     },
     zip_safe=False,
-    classifiers = [
+    classifiers=[
         'Development Status :: 4 - Beta',
         'Framework :: Django',
         'Intended Audience :: Developers',

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ INSTALL_REQUIRES = [
     'django-appconf',
     'django-cms>=2.4',
     'django-classy-tags>=0.3.2',
-    'django-haystack==2.3.2.dev0',
+    'django-haystack>2.3.1,<2.4.0',
     'django-spurl',
     'django-standard-form',
     'aldryn-common',

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ INSTALL_REQUIRES = [
     'django-appconf',
     'django-cms>=2.4',
     'django-classy-tags>=0.3.2',
-    'django-haystack>=2.3.2.dev0,<2.4.0',
+    'django-haystack==2.3.2.dev0',
     'django-spurl',
     'django-standard-form',
     'aldryn-common',

--- a/setup.py
+++ b/setup.py
@@ -9,14 +9,14 @@ INSTALL_REQUIRES = [
     'django-appconf',
     'django-cms>=2.4',
     'django-classy-tags>=0.3.2',
-    'django-haystack>=2.4.0.dev0',
+    'django-haystack>=2.3.2.dev0,<2.4.0',
     'django-spurl',
     'django-standard-form',
     'aldryn-common',
 ]
 
 DEPENDENCY_LINKS = [
-    'https://github.com/chronossc/django-haystack/archive/feature/do_not_index.zip#egg=django-haystack-2.4.0.dev0'  # NOQA
+    'https://github.com/chronossc/django-haystack/archive/2.3.x.zip#egg=django-haystack-2.3.2.dev0'  # NOQA
 ]
 
 setup(

--- a/setup.py
+++ b/setup.py
@@ -9,14 +9,14 @@ INSTALL_REQUIRES = [
     'django-appconf',
     'django-cms>=2.4',
     'django-classy-tags>=0.3.2',
-    'django-haystack>2.3.1,<2.4.0',
+    'django-haystack',
     'django-spurl',
     'django-standard-form',
     'aldryn-common',
 ]
 
 DEPENDENCY_LINKS = [
-    'https://github.com/chronossc/django-haystack/archive/2.3.x.zip#egg=django-haystack-2.3.2.dev0'  # NOQA
+    'https://github.com/chronossc/django-haystack/archive/2.3.x.zip#egg=django-haystack'  # NOQA
 ]
 
 setup(


### PR DESCRIPTION
This PR adds a method that check if obj has it's appconfig namespace in public pages and if not, skip it from indexing.

Depends of PR #1191 of Django Haystack: https://github.com/django-haystack/django-haystack/pull/1191
Depends of that PR be backported Haystack guy to 2.3.x versions, but I keep a backport at https://github.com/chronossc/django-haystack/tree/2.3.x.

Paulo and me agreed to not merge this until there is haystack stable versions with that feature. Was added a doc in aldryn-search README at master about how to use this feature.