### PR TITLE
do not index title if not public

### DIFF
--- a/aldryn_search/search_indexes.py
+++ b/aldryn_search/search_indexes.py
@@ -79,3 +79,6 @@ class TitleIndex(get_index_base()):
             language=language
         ).select_related('page').distinct()
         return queryset
+
+    def should_update(self, instance, **kwargs):
+        return not instance.publisher_is_draft


### PR DESCRIPTION
When an object is saved, haystack triggers the indexing signals which look at ```should_update```, in this case we avoid indexing a title that is *not* public