### PR TITLE
currently aldryn does not support search.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -3,7 +3,6 @@ aldryn-search
 =================
 
 This package provides a search indexes for easy Haystack 2 integration with django CMS.
-The package is compatible with `Aldryn <http://www.aldryn.com>`_.
 
 Usage
 =====


### PR DESCRIPTION
Reverts both 02d697137cbba69044d34dd42621fc42873e5759 and  232b4dcde90cfa8a12523d6ee71fb9b7bd0bf420