### PR TITLE
Fixes should_update depending on publishing state

### DIFF
--- a/aldryn_search/search_indexes.py
+++ b/aldryn_search/search_indexes.py
@@ -143,4 +143,4 @@ class TitleIndex(get_index_base()):
         return queryset
 
     def should_update(self, instance, **kwargs):
-        return not instance.publisher_is_draft
+        return not instance.publisher_is_draft and instance.published


### PR DESCRIPTION
Fixes enqueing drafts when both `instance.publisher_is_draft` and `instance.published` are BOTH `False`. 

I am not sure where exactly the flags are set but I can reliably reproduce both values being set to `False` and `True` at the same time when publishing and unpublishing. This should logically not be possible...