### PR TITLE
Fixes/evict unpublished

### DIFF
--- a/aldryn_search/models.py
+++ b/aldryn_search/models.py
@@ -1,0 +1,1 @@
+from aldryn_search import receivers # @UnusedImport

--- a/aldryn_search/receivers.py
+++ b/aldryn_search/receivers.py
@@ -11,7 +11,7 @@ from django.dispatch.dispatcher import receiver
 from aldryn_search.signals import post_unpublish
 
 
-@receiver(post_unpublish_page, dispatch_uid='unpublish_title')
-def on_post_unpublish_page(sender, instance, language, **kwargs):
+@receiver(post_unpublish_page, dispatch_uid='unpublish_page')
+def unpublish_page(sender, instance, language, **kwargs):
     title = instance.publisher_public.get_title_obj(language)
     post_unpublish.send(sender=Title, instance=title)

--- a/aldryn_search/receivers.py
+++ b/aldryn_search/receivers.py
@@ -1,0 +1,17 @@
+# -*- coding: utf-8 -*-
+'''
+Created on Nov 30, 2015
+
+@author: jakob
+'''
+from cms.models.titlemodels import Title
+from cms.signals import post_unpublish as post_unpublish_page
+from django.dispatch.dispatcher import receiver
+
+from aldryn_search.signals import post_unpublish
+
+
+@receiver(post_unpublish_page, dispatch_uid='unpublish_title')
+def on_post_unpublish_page(sender, instance, language, **kwargs):
+    title = instance.publisher_public.get_title_obj(language)
+    post_unpublish.send(sender=Title, instance=title)

--- a/aldryn_search/signals.py
+++ b/aldryn_search/signals.py
@@ -1,0 +1,22 @@
+# -*- coding: utf-8 -*-
+'''
+Created on Nov 30, 2015
+
+@author: jakob
+'''
+from django.dispatch.dispatcher import Signal
+from haystack.signals import RealtimeSignalProcessor
+
+
+post_unpublish = Signal(providing_args=['instance'])
+
+class AldrynSignalProcessor(RealtimeSignalProcessor):
+    
+    def setup(self):
+        super(AldrynSignalProcessor, self).setup()
+        post_unpublish.connect(self.handle_delete)
+        
+    def teardown(self):
+        super(AldrynSignalProcessor, self).teardown()
+        post_unpublish.disconnect(self.handle_delete)
+


### PR DESCRIPTION
Adds a custom signal processor that allows to handle index deletions when unpublishing objects. Accompanied by a default implementation for the `Title` model.