### PR TITLE
Added unpublishing test and moved singal processor

### DIFF
--- a/aldryn_search/signal_processor.py
+++ b/aldryn_search/signal_processor.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+'''
+Created on Dec 1, 2015
+
+@author: jakob
+'''
+from haystack.signals import RealtimeSignalProcessor
+
+from aldryn_search.signals import post_unpublish
+
+
+class AldrynSignalProcessor(RealtimeSignalProcessor):
+    
+    def setup(self):
+        super(AldrynSignalProcessor, self).setup()
+        post_unpublish.connect(self.handle_delete)
+        
+    def teardown(self):
+        super(AldrynSignalProcessor, self).teardown()
+        post_unpublish.disconnect(self.handle_delete)

--- a/aldryn_search/signals.py
+++ b/aldryn_search/signals.py
@@ -5,18 +5,5 @@ Created on Nov 30, 2015
 @author: jakob
 '''
 from django.dispatch.dispatcher import Signal
-from haystack.signals import RealtimeSignalProcessor
-
 
 post_unpublish = Signal(providing_args=['instance'])
-
-class AldrynSignalProcessor(RealtimeSignalProcessor):
-    
-    def setup(self):
-        super(AldrynSignalProcessor, self).setup()
-        post_unpublish.connect(self.handle_delete)
-        
-    def teardown(self):
-        super(AldrynSignalProcessor, self).teardown()
-        post_unpublish.disconnect(self.handle_delete)
-

--- a/aldryn_search/tests.py
+++ b/aldryn_search/tests.py
@@ -1,17 +1,17 @@
-from django.template import Template
-from django.test import TestCase
-
 from cms.api import create_page, add_plugin
+from cms.models import CMSPlugin, Title
+from cms.models.placeholdermodel import Placeholder
 from cms.plugin_base import CMSPluginBase
 from cms.plugin_pool import plugin_pool
-from cms.models.placeholdermodel import Placeholder
-from cms.models import CMSPlugin, Title
-
-from aldryn_search.search_indexes import TitleIndex
-from .helpers import get_plugin_index_data, get_request
-
+from django.template import Template
+from django.test import TestCase
 from haystack import connections
 from haystack.constants import DEFAULT_ALIAS
+from haystack.query import SearchQuerySet
+
+from aldryn_search.search_indexes import TitleIndex
+
+from .helpers import get_plugin_index_data, get_request
 
 
 class FakeTemplateLoader(object):
@@ -328,3 +328,13 @@ class PluginExcludeAndFilterIndexingTests8(BaseTestCase):
         indexed = index.prepared_data
         self.assertEqual('test_page8', indexed['title'])
         self.assertEqual('test_page8 rendered plugin content never search for this content', indexed['text'])
+
+class UnpublishTest(BaseTestCase):
+        
+    def test_unpublish_page(self):
+        page = create_page('test page', 'test.html', 'en', published=True)
+        title = page.publisher_public.get_title_obj('en')
+        self.assertEqual(1, SearchQuerySet().models(Title).filter(id=title.pk).count())
+        page.unpublish('en')
+        self.assertEqual(0, SearchQuerySet().models(Title).filter(id=title.pk).count())
+        

--- a/test_settings.py
+++ b/test_settings.py
@@ -36,6 +36,7 @@ HELPER_SETTINGS = {
     'LANGUAGE_CODE': 'en',
     #'TEMPLATE_LOADERS': ('aldryn_search.tests.FakeTemplateLoader',),
     'HAYSTACK_CONNECTIONS': HAYSTACK_CONNECTIONS,
+    'HAYSTACK_SIGNAL_PROCESSOR': 'aldryn_search.signal_processor.AldrynSignalProcessor',
     'CMS_PERMISSION': True,
     'CMS_PLACEHOLDER_CONF': {
         'content': {},


### PR DESCRIPTION
Hey,

I added a test for the unpublishing. I was able to run it successfully with elastic search as a backend (solr needed configuration, simple engine does neither supports removal nor `models()`). Also had to move the signal processor to a separate module, otherwise the tests would fail due to circular imports.
Hope this makes sense

Regards

Jakob