### PR TITLE
add changed date to index

### DIFF
--- a/aldryn_search/base.py
+++ b/aldryn_search/base.py
@@ -101,6 +101,7 @@ class AldrynIndexBase(AbstractIndex):
     language = indexes.CharField()
     description = indexes.CharField(indexed=False, stored=True, null=True)
     pub_date = indexes.DateTimeField(null=True)
+    changed_date = indexes.DateTimeField(null=True)
     login_required = indexes.BooleanField(default=False)
     url = indexes.CharField(stored=True, indexed=False)
     title = indexes.CharField(stored=True, indexed=False)

--- a/aldryn_search/search_indexes.py
+++ b/aldryn_search/search_indexes.py
@@ -20,6 +20,9 @@ class TitleIndex(get_index_base()):
     def prepare_pub_date(self, obj):
         return obj.page.publication_date
 
+    def prepare_changed_date(self, obj):
+        return obj.page.changed_date
+
     def prepare_login_required(self, obj):
         return obj.page.login_required
 


### PR DESCRIPTION
I hope this is not a stupid pull request :) 

Bit as it seems the published date remains the same after the very first publish. Published changes are reflected in the changed_date. In our case this value is far more interesting and i thought we might not be the only ones.

Thanks for your great work. 