### PR TITLE
Fix deprecation warning for Django 1.10

### DIFF
--- a/aldryn_search/cms_app.py
+++ b/aldryn_search/cms_app.py
@@ -1,4 +1,4 @@
-from django.conf.urls import patterns, url
+from django.conf.urls import url
 from django.utils.translation import ugettext_lazy as _
 
 from cms.app_base import CMSApp
@@ -12,10 +12,7 @@ from .conf import settings
 class AldrynSearchApphook(CMSApp):
     name = _("aldryn search")
     urls = [
-        patterns(
-            '',
-            url('^$', AldrynSearchView.as_view(), name='aldryn-search'),
-        )
+        url('^$', AldrynSearchView.as_view(), name='aldryn-search'),
     ]
 
 


### PR DESCRIPTION
This removes the following warning:

    .../aldryn_search/cms_app.py:17: RemovedInDjango110Warning: 
    django.conf.urls.patterns() is deprecated and will be removed in Django 1.10. Update your urlpatterns to be a list of django.conf.urls.url() instances instead.
      url('^$', AldrynSearchView.as_view(), name='aldryn-search'),