### PR TITLE
Django CMS 3.5 compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -48,7 +48,7 @@ install:
   - pip install tox coveralls
 
 script:
-  - tox -e $TOX_ENV
+  - tox -e $TOXENV
 
 after_success:
   - coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,39 +4,45 @@ language: python
 sudo: false
 
 env:
-  - TOX_ENV=flake8
-  # Django 1.9
-  - TOX_ENV=py34-dj19-cms32
-  - TOX_ENV=py27-dj19-cms32
-  # Django 1.8
-  - TOX_ENV=py34-dj18-cms32
-  - TOX_ENV=py34-dj18-cms31
-  - TOX_ENV=py33-dj18-cms32
-  - TOX_ENV=py33-dj18-cms31
-  - TOX_ENV=py27-dj18-cms32
-  - TOX_ENV=py27-dj18-cms31
-    # Django 1.7
-  - TOX_ENV=py34-dj17-cms32
-  - TOX_ENV=py34-dj17-cms31
-  - TOX_ENV=py34-dj17-cms30
-  - TOX_ENV=py33-dj17-cms32
-  - TOX_ENV=py33-dj17-cms31
-  - TOX_ENV=py33-dj17-cms30
-  - TOX_ENV=py27-dj17-cms31
-  - TOX_ENV=py27-dj17-cms30
-    # Django 1.6
-  - TOX_ENV=py27-dj16-cms31
-  - TOX_ENV=py27-dj16-cms30
-  - TOX_ENV=py27-dj16-cms30
-  - TOX_ENV=py26-dj16-cms30
-  - TOX_ENV=py26-dj16-cms31
-    # Django 1.5
-  - TOX_ENV=py27-dj15-cms30
-  - TOX_ENV=py26-dj15-cms30
-    # Django 1.4
-  - TOX_ENV=py27-dj14-cms30
-  - TOX_ENV=py26-dj14-cms30
+  - TOXENV=flake8
 
+  - TOXENV=py35-dj111-cms35
+  - TOXENV=py35-dj111-cms34
+  - TOXENV=py34-dj111-cms35
+  - TOXENV=py34-dj111-cms34
+  - TOXENV=py27-dj111-cms35
+  - TOXENV=py27-dj111-cms34
+
+  - TOXENV=py35-dj110-cms35
+  - TOXENV=py35-dj110-cms34
+  - TOXENV=py34-dj110-cms35
+  - TOXENV=py34-dj110-cms34
+  - TOXENV=py27-dj110-cms35
+  - TOXENV=py27-dj110-cms34
+
+  - TOXENV=py35-dj19-cms34
+  - TOXENV=py35-dj19-cms33
+  - TOXENV=py35-dj19-cms32
+  - TOXENV=py34-dj19-cms34
+  - TOXENV=py34-dj19-cms33
+  - TOXENV=py34-dj19-cms32
+  - TOXENV=py27-dj19-cms34
+  - TOXENV=py27-dj19-cms33
+  - TOXENV=py27-dj19-cms32
+
+  - TOXENV=py35-dj18-cms34
+  - TOXENV=py35-dj18-cms33
+  - TOXENV=py35-dj18-cms32
+  - TOXENV=py34-dj18-cms34
+  - TOXENV=py34-dj18-cms33
+  - TOXENV=py34-dj18-cms32
+  - TOXENV=py27-dj18-cms34
+  - TOXENV=py27-dj18-cms33
+  - TOXENV=py27-dj18-cms32
+
+cache:
+  directories:
+    - $HOME/.wheelhouse
 
 install:
   - pip install tox coveralls

--- a/aldryn_search/cms_apps.py
+++ b/aldryn_search/cms_apps.py
@@ -8,10 +8,9 @@ from .conf import settings
 
 class AldrynSearchApphook(CMSApp):
     name = _("aldryn search")
-    urls = ['aldryn_search.urls']
 
     def get_urls(self, *args, **kwargs):
-        return self.urls
+        return ['aldryn_search.urls']
 
 
 if settings.ALDRYN_SEARCH_REGISTER_APPHOOK:

--- a/aldryn_search/cms_apps.py
+++ b/aldryn_search/cms_apps.py
@@ -10,6 +10,9 @@ class AldrynSearchApphook(CMSApp):
     name = _("aldryn search")
     urls = ['aldryn_search.urls']
 
+    def get_urls(self, *args, **kwargs):
+        return self.urls
+
 
 if settings.ALDRYN_SEARCH_REGISTER_APPHOOK:
     apphook_pool.register(AldrynSearchApphook)

--- a/aldryn_search/compat.py
+++ b/aldryn_search/compat.py
@@ -1,0 +1,6 @@
+from distutils.version import LooseVersion
+
+import cms
+
+
+GTE_CMS_35 = LooseVersion(cms.__version__) >= LooseVersion('3.5')

--- a/aldryn_search/search_indexes.py
+++ b/aldryn_search/search_indexes.py
@@ -26,7 +26,12 @@ class TitleIndex(get_index_base()):
         return obj.page.login_required
 
     def prepare_site_id(self, obj):
-        return obj.page.site_id
+        try:
+            # django-cms>=3.5
+            return obj.page.node.site_id
+        except AttributeError:
+            # django-cms<=3.4
+            return obj.page.site_id
 
     def get_language(self, obj):
         return obj.language

--- a/aldryn_search/tests.py
+++ b/aldryn_search/tests.py
@@ -3,7 +3,7 @@ from cms.models import CMSPlugin, Title
 from cms.models.placeholdermodel import Placeholder
 from cms.plugin_base import CMSPluginBase
 from cms.plugin_pool import plugin_pool
-from django.template import Template
+from django.template import engines
 from django.test import TestCase
 from haystack import connections
 from haystack.constants import DEFAULT_ALIAS
@@ -12,6 +12,12 @@ from haystack.query import SearchQuerySet
 from aldryn_search.search_indexes import TitleIndex
 
 from .helpers import get_plugin_index_data, get_request
+
+
+def template_from_string(value):
+    """Create an engine-specific template based on provided string.
+    """
+    return engines.all()[0].from_string(value)
 
 
 class FakeTemplateLoader(object):
@@ -28,7 +34,7 @@ class FakeTemplateLoader(object):
 class NotIndexedPlugin(CMSPluginBase):
     model = CMSPlugin
     plugin_content = 'rendered plugin content'
-    render_template = Template(plugin_content)
+    render_template = template_from_string(plugin_content)
 
     def render(self, context, instance, placeholder):
         return context
@@ -39,7 +45,7 @@ plugin_pool.register_plugin(NotIndexedPlugin)
 class HiddenPlugin(CMSPluginBase):
     model = CMSPlugin
     plugin_content = 'never search for this content'
-    render_template = Template(plugin_content)
+    render_template = template_from_string(plugin_content)
 
     def render(self, context, instance, placeholder):
         return context

--- a/setup.py
+++ b/setup.py
@@ -5,9 +5,9 @@ from setuptools import setup, find_packages
 install_requires = [
     'lxml',
     'setuptools',
-    'Django>=1.4',
+    'Django>=1.8,<2.0',
     'django-appconf',
-    'django-cms>=3.0',
+    'django-cms>=3.2',
     'django-haystack>=2.0.0',
     'django-spurl',
     'django-standard-form',
@@ -35,10 +35,18 @@ setup(
     classifiers = [
         'Development Status :: 4 - Beta',
         'Framework :: Django',
+        'Framework :: Django :: 1.8',
+        'Framework :: Django :: 1.9',
+        'Framework :: Django :: 1.10',
+        'Framework :: Django :: 1.11',
         'Intended Audience :: Developers',
         'License :: OSI Approved :: BSD License',
         'Operating System :: OS Independent',
         'Programming Language :: Python',
+        'Programming Language :: Python :: 2.7',
+        'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
         'Topic :: Internet :: WWW/HTTP',
     ]
 )

--- a/test_requirements/django_1.10.txt
+++ b/test_requirements/django_1.10.txt
@@ -1,0 +1,3 @@
+-r base.txt
+Django>=1.10,<1.11
+djangocms-helper>=0.9.7

--- a/test_requirements/django_1.11.txt
+++ b/test_requirements/django_1.11.txt
@@ -1,0 +1,3 @@
+-r base.txt
+Django>=1.11,<2.0
+djangocms-helper>=1.1.0

--- a/test_requirements/django_1.4.txt
+++ b/test_requirements/django_1.4.txt
@@ -1,4 +1,0 @@
--r base.txt
-Django<1.5
-djangocms-helper==0.8.1
-django-discover-runner

--- a/test_requirements/django_1.5.txt
+++ b/test_requirements/django_1.5.txt
@@ -1,4 +1,0 @@
--r base.txt
-Django<1.6
-djangocms-helper==0.8.1
-django-discover-runner

--- a/test_requirements/django_1.6.txt
+++ b/test_requirements/django_1.6.txt
@@ -1,3 +1,0 @@
--r base.txt
-Django<1.7
-djangocms-helper>=0.9.2,<0.10

--- a/test_requirements/django_1.7.txt
+++ b/test_requirements/django_1.7.txt
@@ -1,3 +1,0 @@
--r base.txt
-Django<1.8
-djangocms-helper>=0.9.2,<0.10

--- a/test_settings.py
+++ b/test_settings.py
@@ -5,6 +5,7 @@
 def gettext(s):
     return s
 
+
 HAYSTACK_CONNECTIONS = {
     'default': {
         'ENGINE': 'haystack.backends.solr_backend.SolrEngine',
@@ -71,6 +72,7 @@ HELPER_SETTINGS = {
 def run():
     from djangocms_helper import runner
     runner.cms('aldryn_search')
+
 
 if __name__ == '__main__':
     run()

--- a/tox.ini
+++ b/tox.ini
@@ -36,4 +36,4 @@ basepython = python2.7
 [flake8]
 ignore = E251,E128
 max-line-length = 120
-exclude = aldryn_search/tests.py,aldryn_search/test_settings.py,docs/conf.py
+exclude = build/*,aldryn_search/tests.py,docs/conf.py,.tox/*

--- a/tox.ini
+++ b/tox.ini
@@ -1,13 +1,7 @@
 [tox]
 envlist =
-    flake8
-    py{34,27}-dj19-cms32
-    py{34,33,27}-dj18-cms{32,31}
-    py{34,33}-dj17-cms{32,31,30}
-    py27-dj{17,16}-cms{31,30}
-    py{27,26}-dj16-cms31
-    py{27,26}-dj15-cms{31,30}
-    py{27,26}-dj14-cms30
+    py{36,35,34,27}-dj{19,18}-cms{34,33,32}
+    py{36,35,34,27}-dj{111,110}-cms{34,35}
 skip_missing_interpreters=True
 
 [testenv]
@@ -16,20 +10,28 @@ commands =
     coverage erase
     coverage run test_settings.py
     coverage report
-deps=
-    cms30: django-cms>=3.0.12,<3.1
-    cms31: django-cms>=3.1,<3.2
-    cms32: django-cms>=3.2,<3.3
-    dj14: -rtest_requirements/django_1.4.txt
-    dj15: -rtest_requirements/django_1.5.txt
-    dj16: -rtest_requirements/django_1.6.txt
-    dj17: -rtest_requirements/django_1.7.txt
+deps =
     dj18: -rtest_requirements/django_1.8.txt
     dj19: -rtest_requirements/django_1.9.txt
+    dj110: -rtest_requirements/django_1.10.txt
+    dj111: -rtest_requirements/django_1.11.txt
+
+    cms32: django-cms>=3.2,<3.3
+    cms33: django-cms>=3.3,<3.4
+    cms34: django-cms>=3.4,<3.5
+    cms35: django-cms>=3.5,<3.6
+
+basepython =
+    py27: python2.7
+    py33: python3.3
+    py34: python3.4
+    py35: python3.5
+    py36: python3.6
 
 [testenv:flake8]
 deps = flake8
 commands = flake8
+basepython = python2.7
 
 [flake8]
 ignore = E251,E128


### PR DESCRIPTION
Fix a test not using engine-specific template
Switch to supported Django and Django CMS versions in tox
Add classifiers for supported Django/Python versions