### PR TITLE
Load conf via Django's AppConfig

### DIFF
--- a/aldryn_search/apps.py
+++ b/aldryn_search/apps.py
@@ -1,0 +1,8 @@
+from django.apps import AppConfig
+
+
+class AldrynSearchConfig(AppConfig):
+    name = 'aldryn_search'
+
+    def ready(self):
+        from . import conf  # noqa


### PR DESCRIPTION
This fixes a problem when running tests that use the `override_settings`
decorator and aldryn-search's `AppConf` hasn't been initialised leading to
errors like:
`AttributeError: 'Settings' object has no attribute 'ALDRYN_SEARCH_INDEX_BASE_CLASS'`

You'll need to change `INSTALLED_APPS` to include `aldryn_search.apps.AldrynSearchConfig`